### PR TITLE
fix: heroku deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ npm-debug.log*
 # dotenv environment variables file
 .env
 .env.test
+
+# Local Config
+.vscode/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:local": "DB_ENV=local nodemon ./src/server.js",
-    "start": "nodemon ./src/server.js",
+    "start": "node ./src/server.js",
     "lint": "eslint . --ext .js",
     "lint:fix": "npm run lint -- --fix"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,4 @@
-const dotenv = require('dotenv');
+require('dotenv').config();
 const express = require('express');
 
 const connectDB = require('./config/db');
@@ -8,8 +8,6 @@ const packageRouter = require('./routes/package');
 const transactionRouter = require('./routes/transaction');
 const donationRouter = require('./routes/donation');
 
-
-dotenv.config();
 const app = express();
 
 // Connect Database


### PR DESCRIPTION
Moves the `dotenv` config to the start of the document, and changes the start script from `nodemon` to `node` .